### PR TITLE
Lock down json response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dotcodegen (0.1.5)
+    dotcodegen (0.1.6)
       dotenv
       front_matter_parser
       ruby-openai

--- a/lib/dotcodegen/lint_code.rb
+++ b/lib/dotcodegen/lint_code.rb
@@ -23,7 +23,6 @@ module Dotcodegen
       end
     end
 
-
     def standardrb_code
       puts "Linting: StandardRB"
       system("standardrb --fix-unsafely #{@file_path}")

--- a/lib/dotcodegen/test_code_generator.rb
+++ b/lib/dotcodegen/test_code_generator.rb
@@ -19,6 +19,7 @@ module Dotcodegen
         parameters: {
           model: 'gpt-4-turbo-preview',
           messages: [{ role: 'user', content: test_prompt_text }], # Required.
+          response_format: { type: "json_object" },
           temperature: 0.7
         }
       )

--- a/lib/dotcodegen/test_code_generator.rb
+++ b/lib/dotcodegen/test_code_generator.rb
@@ -17,7 +17,7 @@ module Dotcodegen
     def generate_test_code
       response = openai_client.chat(
         parameters: {
-          model: 'gpt-4-turbo-preview',
+          model: 'gpt-4o',
           messages: [{ role: 'user', content: test_prompt_text }], # Required.
           response_format: { type: "json_object" },
           temperature: 0.7

--- a/lib/dotcodegen/version.rb
+++ b/lib/dotcodegen/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dotcodegen
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
https://github.com/alexrudall/ruby-openai?tab=readme-ov-file#json-mode


FormatOutput can be argued as not needed, but the class could come in handy if Claude or other LLMs have backticks in their output, hence I left it there